### PR TITLE
Fixes 404

### DIFF
--- a/Style Guide/Introduction.md
+++ b/Style Guide/Introduction.md
@@ -10,7 +10,7 @@ This document is an attempt to come to an agreement on a style-guide because we 
 
 - [Code Layout and Formatting](Code Layout and Formatting.md)
 - [Function Structure](Function Structure.md)
-- [Documentation and Comments](Style Guide/Documentation and Comments.md)
+- [Documentation and Comments](Documentation and Comments.md)
 - [Readability](Readability.md)
 - [Naming Conventions](Naming Conventions.md)
 


### PR DESCRIPTION
A bad link on "Style Guide\Introduction.md" that results in a 404. Removed
the redundant "Style Guide" folder and the link works again.