### PR TITLE
Fixed typo in Best Practices/Error Handling.md

### DIFF
--- a/Best Practices/Error Handling.md
+++ b/Best Practices/Error Handling.md
@@ -56,7 +56,7 @@ $user = Get-ADUser -Identity DonJ
 
 if ($user) {
     $user | Do-Something
-} else [
+} else {
     Write-Warning "Could not get user $user"
 }
 ```


### PR DESCRIPTION
Fixed a typo where a square bracket ([) was used instead of a curly bracket ({) in the if/else statement example.