### PR TITLE
Add links to to-do items

### DIFF
--- a/Best Practices/Naming Conventions.md
+++ b/Best Practices/Naming Conventions.md
@@ -1,2 +1,3 @@
-TODO: Copy #36 Capitalization guidelines
-TODO: Copy #23 Command Prefixes
+TODO: Copy [#36](https://github.com/PoshCode/PowerShellPracticeAndStyle/issues/36) Capitalization guidelines
+
+TODO: Copy [#23](https://github.com/PoshCode/PowerShellPracticeAndStyle/issues/23) Command Prefixes


### PR DESCRIPTION
Add links to to-do items to make reading work-in-progress content easier

Separate the two to-do items by a newline to make them render on separate lines