### PR TITLE
fix broken links (commas have been removed in previous commits)

### DIFF
--- a/Best-Practices/Introduction.md
+++ b/Best-Practices/Introduction.md
@@ -20,5 +20,5 @@ One final note about these Best Practices: the perspective of these guidelines h
 - [Error Handling](Error-Handling.md)
 - [Performance](Performance.md)
 - [Security](Security.md)
-- [Language, Interop and .Net](Language,-Interop-and-.Net.md)
-- [Metadata, Versioning, and Packaging](Metadata,-Versioning,-and-Packaging.md)
+- [Language, Interop and .Net](Language-Interop-and-.Net.md)
+- [Metadata, Versioning, and Packaging](Metadata-Versioning-and-Packaging.md)

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ The guidelines are divided into these sections:
   * [Error Handling](Best-Practices/Error-Handling.md)
   * [Performance](Best-Practices/Performance.md)
   * [Security](Best-Practices/Security.md)
-  * [Language, Interop and .Net](Best-Practices/Language%2C-Interop-and-.Net.md)
-  * [Metadata, Versioning, and Packaging](Best-Practices/Metadata%2C-Versioning%2C-and-Packaging.md)
+  * [Language, Interop and .Net](Best-Practices/Language-Interop-and-.Net.md)
+  * [Metadata, Versioning, and Packaging](Best-Practices/Metadata-Versioning-and-Packaging.md)
 
 ### Current State:
 


### PR DESCRIPTION
Hi,
I found three more URLs which have been fixed incorrectly in https://github.com/PoshCode/PowerShellPracticeAndStyle/pull/90.

Best regards :smile:
