### PR TITLE
Summarize instead of duplicate

### DIFF
--- a/Style-Guide/Code-Layout-and-Formatting.md
+++ b/Style-Guide/Code-Layout-and-Formatting.md
@@ -60,7 +60,7 @@ function Write-Host {
     ...
 ```
 
-PowerShell uses PascalCase for _all_ public identifiers: module names, function or cmdlet names, class and enum names, public fields or properties, global variables and constants, etc. In fact, since the _parameters_ to PowerShell commands are actually _properties_ of .Net classes, even parameters use PascalCase rather than camelCase. Function names should follow PowerShell's `Verb-Noun` naming conventions, using PascalCase within both Verb and Noun.
+As stated previously, PowerShell uses PascalCase for _all_ public identifiers. Function names should follow PowerShell's `Verb-Noun` naming conventions, using PascalCase within both Verb and Noun.
 
 A special case is made for two-letter acronyms in which both letters are capitalized, as in the variable `$PSBoundParameters` or the command `Get-PSDrive`. Note that ([as specified in the .NET guidelines](https://msdn.microsoft.com/en-us/library/ms229043#Anchor_1)) this does not affect the commonly capitalized (but not acronym) words "OK" and "ID" . You should also not extend it to compound acronyms, such as when Azure's Resource Manager (RM) meets a Virtual Machine (VM) in `Start-AzureRmVM`...
 
@@ -181,7 +181,7 @@ Nested expressions `$( ... )` and variable delimiters `${...}` inside strings do
 
 #### Avoid using semicolons (`;`) at the end of each line.
 
-PowerShell will not complain about extra semicolons, but they are unecessary, and get in the way when code is being edited or copy-pasted. They also result in extra do-nothing edits in source control when someone finally decides to delete them.
+PowerShell will not complain about extra semicolons, but they are unnecessary, and get in the way when code is being edited or copy-pasted. They also result in extra do-nothing edits in source control when someone finally decides to delete them.
 
 They are also unecessary when declaring hashtables if you are already putting each element on it's own line:
 


### PR DESCRIPTION
Summarize a duplicated sentence and corrected spelling of 'unnecessary'.