### PR TITLE
Add whitespace to equal signs in parameters

### DIFF
--- a/Best-Practices/Error-Handling.md
+++ b/Best-Practices/Error-Handling.md
@@ -2,9 +2,9 @@
 
 When trapping an error, try to use -ErrorAction Stop on cmdlets to generate terminating, trappable exceptions.
 
-# ERR-02 Use $ErrorActionPreference='Stop' or 'Continue' when calling non-cmdlets
+# ERR-02 Use $ErrorActionPreference = 'Stop' or 'Continue' when calling non-cmdlets
 
-When executing something other than a cmdlet, set $ErrorActionPreference='Stop' before executing, and re-set to Continue afterwards. If you're concerned about using -ErrorAction because it will bail on the entire pipeline, then you've probably over-constructed the pipeline. Consider using a more scripting-construct-style approach, because those approaches are inherently better for automated error handling.
+When executing something other than a cmdlet, set $ErrorActionPreference = 'Stop' before executing, and re-set to Continue afterwards. If you're concerned about using -ErrorAction because it will bail on the entire pipeline, then you've probably over-constructed the pipeline. Consider using a more scripting-construct-style approach, because those approaches are inherently better for automated error handling.
 
 Ideally, whatever command or code you think might bomb should be dealing with one thing: querying one computer, deleting one file, updating one user. That way, if an error occurs, you can handle it and then get on with the next thing.
 

--- a/Best-Practices/TODO.md
+++ b/Best-Practices/TODO.md
@@ -149,8 +149,8 @@ It doesn't do anything, and it confuses future readers.
 When prompted for a mandatory parameter, a user can request HelpText, but can't look at the documentation. It's frequently useful to duplicate at least the first sentence or two of the parameter help.
 
 ```
-[Parameter(Position=1, Mandatory=$true, ValueFromPipeline=$true,
-ValueFromPipelineByPropertyName=$true, HelpText='The name of the file to read')]
+[Parameter(Position = 1, Mandatory = $true, ValueFromPipeline = $true,
+ValueFromPipelineByPropertyName = $true, HelpText = 'The name of the file to read')]
 [Alias('PSPath','FullName','Path')]
 [String]$File
 ```
@@ -208,7 +208,7 @@ Discuss: when is this critical (-whatif) and optional (-confirm_
 Discuss: when should you call PSCmdlet.ShouldProcess vs PSCmdlet.ShouldContinue (-Force)
 
 ```
-[CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact="Medium")]
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Medium")]
 param([Switch]$Force)
 
 $RejectAll = $false;

--- a/Style-Guide/Code-Layout-and-Formatting.md
+++ b/Style-Guide/Code-Layout-and-Formatting.md
@@ -39,7 +39,7 @@ function Write-Host {
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Position=0, ValueFromPipeline=$true, ValueFromRemainingArguments=$true)]
+        [Parameter(Position = 0, ValueFromPipeline = $true, ValueFromRemainingArguments = $true)]
         [PSObject]
         $Object,
 

--- a/Style-Guide/Documentation-and-Comments.md
+++ b/Style-Guide/Documentation-and-Comments.md
@@ -84,9 +84,9 @@ Examples can be found in the ISE snippets:
 ```powershell
 Param(
     # Param1 help description
-    [Parameter(Mandatory=$true,
-                ValueFromPipelineByPropertyName=$true,
-                Position=0)]
+    [Parameter(Mandatory = $true,
+                ValueFromPipelineByPropertyName = $true,
+                Position = 0)]
     $Param1,
     
     # Param2 help description
@@ -116,7 +116,7 @@ function Test-Help {
     param(
         # This parameter doesn't do anything.
         # Aliases: MP
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [Alias("MP")]
         [String]$MandatoryParameter
     )

--- a/Style-Guide/Function-Structure.md
+++ b/Style-Guide/Function-Structure.md
@@ -28,9 +28,9 @@ function Get-USCitizenCapability {
     [CmdletBinding()]
     [OutputType([psobject])]
     param (
-        [Parameter(Mandatory=$true,
-                   ValueFromPipelineByPropertyName=$true,
-                   Position=0)]
+        [Parameter(Mandatory = $true,
+                   ValueFromPipelineByPropertyName = $true,
+                   Position = 0)]
         [int16]
         $Age
     )
@@ -55,9 +55,9 @@ function Get-USCitizenCapability {
     [CmdletBinding()]
     [OutputType([psobject])]
     param (
-        [Parameter(Mandatory=$true,
-                   ValueFromPipelineByPropertyName=$true,
-                   Position=0)]
+        [Parameter(Mandatory = $true,
+                   ValueFromPipelineByPropertyName = $true,
+                   Position = 0)]
         [int16]
         $Age
     )
@@ -87,23 +87,23 @@ function Get-USCitizenCapability {
 If the function returns different object types depending on the parameter set provide one per parameter set.
 
 ```PowerShell
-[OutputType([<TypeLiteral>], ParameterSetName="<Name>")]
-[OutputType("<TypeNameString>", ParameterSetName="<Name>")]
+[OutputType([<TypeLiteral>], ParameterSetName = "<Name>")]
+[OutputType("<TypeNameString>", ParameterSetName = "<Name>")]
 ```
 
 #### When a ParameterSetName is used in any of the parameters, always provide a DefaultParameterSetName in the CmdletBinding attribute.
 
 ```PowerShell
 function Get-User {
-    [CmdletBinding(DefaultParameterSetName="ID")]
-    [OutputType("System.Int32", ParameterSetName="ID")]
-    [OutputType([String], ParameterSetName="Name")]
+    [CmdletBinding(DefaultParameterSetName = "ID")]
+    [OutputType("System.Int32", ParameterSetName = "ID")]
+    [OutputType([String], ParameterSetName = "Name")]
     param (      
-        [parameter(Mandatory=$true, ParameterSetName="ID")]
+        [parameter(Mandatory = $true, ParameterSetName = "ID")]
         [Int[]]
         $UserID,
 
-        [parameter(Mandatory=$true, ParameterSetName="Name")]
+        [parameter(Mandatory = $true, ParameterSetName = "Name")]
         [String[]]
         $UserName
     )     
@@ -119,7 +119,7 @@ function Get-User {
 
   ```PowerShell
   param (
-      [Parameter(Mandatory=$true)]
+      [Parameter(Mandatory = $true)]
       [AllowNull()]
       [String]
       $ComputerName
@@ -132,7 +132,7 @@ function Get-User {
 
   ```PowerShell
   param (
-      [Parameter(Mandatory=$true)]
+      [Parameter(Mandatory = $true)]
       [AllowEmptyString()]
       [String]
       $ComputerName
@@ -145,7 +145,7 @@ function Get-User {
 
   ```PowerShell
   param (
-      [Parameter(Mandatory=$true)]
+      [Parameter(Mandatory = $true)]
       [AllowEmptyCollection()]
       [String[]]
       $ComputerName
@@ -161,7 +161,7 @@ function Get-User {
 
   ```PowerShell
   param (
-      [Parameter(Mandatory=$true)]
+      [Parameter(Mandatory = $true)]
       [ValidateCount(1,5)]
       [String[]]
       $ComputerName
@@ -177,7 +177,7 @@ function Get-User {
 
   ```PowerShell
   param (
-      [Parameter(Mandatory=$true)]
+      [Parameter(Mandatory = $true)]
       [ValidateLength(1,10)]
       [String[]]
       $ComputerName
@@ -192,7 +192,7 @@ function Get-User {
   pattern. 
   ```PowerShell
   param (
-      [Parameter(Mandatory=$true)]
+      [Parameter(Mandatory = $true)]
       [ValidatePattern("[0-9][0-9][0-9][0-9]")]
       [String[]]
       $ComputerName
@@ -206,7 +206,7 @@ function Get-User {
   if any value is outside that range. 
   ```PowerShell
   param (
-      [Parameter(Mandatory=$true)]
+      [Parameter(Mandatory = $true)]
       [ValidateRange(0,10)]
       [Int]
       $Attempts
@@ -243,7 +243,7 @@ function Get-User {
 
   ```PowerShell
   param (
-      [Parameter(Mandatory=$true)]
+      [Parameter(Mandatory = $true)]
       [ValidateSet("Low", "Average", "High")]
       [String[]]
       $Detail
@@ -264,7 +264,7 @@ function Get-User {
   match the specified type.)  
   ```PowerShell
   param (
-      [Parameter(Mandatory=$true)]
+      [Parameter(Mandatory = $true)]
       [ValidateNotNull()]
       $ID
   ) 
@@ -279,7 +279,7 @@ function Get-User {
   array.   
   ```PowerShell
   param (
-      [Parameter(Mandatory=$true)]
+      [Parameter(Mandatory = $true)]
       [ValidateNotNullOrEmpty()]
       [String[]]
       $UserName


### PR DESCRIPTION
The documentation here seems to suggest that whitespace should be used in parameter names, while the example documentation lacks spaces. A quick poll on PowerShell Slack voted unanimously on adding spaces, so I volunteered to make the changes throughout the documentation.