### PR TITLE
Replaced "param()" with "param ()" for consistency.

### DIFF
--- a/Style-Guide/Code-Layout-and-Formatting.md
+++ b/Style-Guide/Code-Layout-and-Formatting.md
@@ -38,7 +38,7 @@ function Write-Host {
     hosting Windows PowerShell.
     #>
     [CmdletBinding()]
-    param(
+    param (
         [Parameter(Position = 0, ValueFromPipeline = $true, ValueFromRemainingArguments = $true)]
         [PSObject]
         $Object,
@@ -81,7 +81,7 @@ enum Color {
 
 function Test-Code {
     [CmdletBinding()]
-    param(
+    param (
         [int]$ParameterOne
     )
     end {
@@ -106,7 +106,7 @@ All of your scripts or functions should start life as something like this snippe
 
 ```powershell
 [CmdletBinding()]
-param()
+param ()
 process {
 }
 end {
@@ -115,7 +115,7 @@ end {
 
 You can always delete or ignore one of the blocks (or add the `begin` block), add parameters and necessary valiation and so on, but you should **avoid** writing scripts or functions without `[CmdletBinding()]`, and you should always at least _consider_ making it take pipeline input.
 
-#### Prefer: param(), begin, process, end
+#### Prefer: param (), begin, process, end
 
 Having a script written in the order of execution makes the intent clearer. Since there is no functional reason to have these blocks out of order (they _will_ still be executed in the normal order), writing them out of order can be confusing, and makes code more difficult to maintain and debug.
 

--- a/Style-Guide/Documentation-and-Comments.md
+++ b/Style-Guide/Documentation-and-Comments.md
@@ -82,7 +82,7 @@ Each parameter should be documented. To make it easier to keep the comments sync
 Examples can be found in the ISE snippets:
 
 ```powershell
-Param(
+param (
     # Param1 help description
     [Parameter(Mandatory = $true,
                 ValueFromPipelineByPropertyName = $true,
@@ -113,7 +113,7 @@ function Test-Help {
             This shows the help for the example function
     #>
     [CmdletBinding()]
-    param(
+    param (
         # This parameter doesn't do anything.
         # Aliases: MP
         [Parameter(Mandatory = $true)]


### PR DESCRIPTION
Most examples in this project use the `param` keywork with a space
before the parentheses, like `param (` or `param ()`. However,
some examples omit the space, or capitalize the P, like `param(` or
`Param(`. This is a needless inconsistency, which this PR addresses.
Note that two instances of `param()` are left in tact, since they are
in a TODO file.

See issue #128.  