### PR TITLE
 Spelling fix for parameter 'Wait' in example

### DIFF
--- a/Style-Guide/Code-Layout-and-Formatting.md
+++ b/Style-Guide/Code-Layout-and-Formatting.md
@@ -196,7 +196,7 @@ One notable exception is when using colons to pass values to switch parameters:
 
 ```PowerShell
 # Do not write:
-$variable=Get-Content $FilePath -Wai:($ReadCount-gt0) -First($ReadCount*5)
+$variable=Get-Content $FilePath -Wait:($ReadCount-gt0) -First($ReadCount*5)
 
 # Instead write:
 $variable = Get-Content -Path $FilePath -Wait:($ReadCount -gt 0) -TotalCount ($ReadCount * 5)


### PR DESCRIPTION
Simple spelling fix